### PR TITLE
Added Prototype 2 Support

### DIFF
--- a/PrototypeScript.ps1
+++ b/PrototypeScript.ps1
@@ -6,12 +6,13 @@ $global:steam_path = "C:\Program Files (x86)\Steam\steam.exe"
 #Feel free to change this value accordingly if Steam takes longer or shorter to load.
 $global:steam_wait_time = 8
 
-#Prototype Default Path Location.
-#Feel free to change this value if you installed Prototype in other location.
-$global:prototype_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype\prototypef.exe"
+#Prototype Games Default Path Locations.
+#Feel free to change these values if you installed games in other locations.
+$global:prototype1_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype\prototypef.exe"
+$global:prototype2_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype 2\prototype2.exe"
 
-#Time to wait for Prototype to load (seconds).
-#Feel free to change this value accordingly if Prototype takes longer or shorter to load.
+#Time to wait for game to load (seconds).
+#Feel free to change this value accordingly if game takes longer or shorter to load.
 $global:prototype_wait_time = 3
 
 
@@ -42,7 +43,15 @@ function SelectProcessor {
 function ExecutePrototype{
     Clear-Host
     SelectProcessor
-    Write-Host "Executing Prototype..."
+    
+	$game_path = $global:prototype1_path
+
+	if($opt -eq 1) {
+		Write-Host "Executing Prototype..."
+	} else {
+		Write-Host "Executing Prototype 2..."
+		$game_path = $global:prototype2_path
+	}
     
     #Checks if Steam Process is Running.
     $steam = Get-Process steam -ErrorAction SilentlyContinue
@@ -62,20 +71,26 @@ function ExecutePrototype{
         $steam.ProcessorAffinity = $global:target_cores
 
         #Executes prototype 
-        start $global:prototype_path
+        start $game_path
 
         #Waits for Prototype process to load in memory.
         start-sleep $global:prototype_wait_time
 
         #Get Prototype Process.
-        $prototype = Get-Process prototypef -ErrorAction SilentlyContinue    
+		$game_process = $null
 
-        if($prototype){
+		if($opt -eq 1) {
+			$game_process = Get-Process prototypef -ErrorAction SilentlyContinue    
+		} else {
+			$game_process = Get-Process prototype2 -ErrorAction SilentlyContinue
+		}  
+
+        if($game_process){
             #Set prototype ProcessorAffinity to use only 4 cores (AMD) 
             #or 8 cores (Intel).
-            $prototype.ProcessorAffinity = $global:target_cores
+            $game_process.ProcessorAffinity = $global:target_cores
         }else{
-            Write-Host "Prototype process not found."
+            Write-Host "Game process not found."
         }
     }else{
         Write-Host "Steam process not found."
@@ -128,30 +143,31 @@ function CheckSteamProcessorAffinity{
 function main{
     do{
         Clear-Host
-        Write-Host "1.- Execute Prototype"
-        Write-Host "2.- Check Steam ProcessorAffinity"
-        Write-Host "3.- Restore Steam ProcessorAffinity"
-        Write-Host "4.- Exit"
+        Write-Host "1.- Execute Prototype 1"
+        Write-Host "2.- Execute Prototype 2"
+        Write-Host "3.- Check Steam ProcessorAffinity"
+        Write-Host "4.- Restore Steam ProcessorAffinity"
+        Write-Host "5.- Exit"
 
         $opt = Read-Host Select an option
 
 
-        if($opt -eq 1){
+        if($opt -eq 1 -or $opt -eq 2){
             ExecutePrototype
         }
 
-        if($opt -eq 2){
+        if($opt -eq 3){
             CheckSteamProcessorAffinity
         }
         
-        if($opt -eq 3){
+        if($opt -eq 4){
             RestoreSteamProcessorAffinity
         }
 
-        if($opt -ne 4){
+        if($opt -ne 5){
             pause
         } 
-    }while($opt -ne 4)
+    }while($opt -ne 5)
 }
 
 main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Steam Prototype Launcher
-A Launcher for Steam's Prototype game that automatically changes the ProcessorAffinity.
+A Launcher for Steam's Prototype and Prototype 2 games that automatically changes the ProcessorAffinity.
 
 I've been running Prototype in Windows 11 but I was getting tired of manually changing the ProcessorAffinity so I found this trick of creating a batch file and then calling "start /affinity FF <steam_games_path>/prototypef.exe" but it did not work for me as it seems it is disabled for security reasons (don't quote me) also in my case in order for this fix to work both the steam.exe and prototypef.exe needs to be changed to use 8 cores.
 
@@ -16,18 +16,18 @@ Just download and unzip the project wherever you want :wink:</br></br>
 <li>
   If the Steam App or the Game library is not located in the default location then you must update the "PrototypeScript.ps1" with the right paths.
 
-  Open the file with a text editor such as notepad and modify the lines 3 and 11.
+  Open the file with a text editor such as notepad and modify the lines 3, 11 and 12.
 
   ```powershell
   $global:steam_path = "C:\Program Files (x86)\Steam\steam.exe"
 
-  $global:prototype_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype\prototypef.exe"
+  $global:prototype1_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype\prototypef.exe"
   ```
   </br>
 </li>
 
 <li>
-  Double click the file "PrototypeLauncher.bat" select the first option by pressing 1 and then enter to run the game.
+  Double click the file "PrototypeLauncher.bat" and select either option 1 or 2 to run either Prototype 1 or 2 respectively.
 
   </br>
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Just download and unzip the project wherever you want :wink:</br></br>
   $global:steam_path = "C:\Program Files (x86)\Steam\steam.exe"
 
   $global:prototype1_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype\prototypef.exe"
+  $global:prototype2_path = "C:\Program Files (x86)\Steam\steamapps\common\Prototype 2\prototype2.exe"
   ```
   </br>
 </li>


### PR DESCRIPTION
Small update to include support for Prototype 2 since it appeared to have the exact same processor affinity issue as Prototype 1. With this update, Prototype 2 now boots up and appears playable. I was able to start up a new game and made it to the first proper gameplay segment.